### PR TITLE
Fix license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@
 
 ## License
 
-[AGPL-3.0](https://github.com/choukh/agda-veblen/blob/main/LICENSE)
+[AGPL-3.0](https://github.com/choukh/agda-googology/blob/main/LICENSE)


### PR DESCRIPTION
## Summary
- update the README license link to reference the current repo

## Testing
- `git log -1 --stat`